### PR TITLE
Add trailers support for HTTP/2 response. 

### DIFF
--- a/lib/machine_gun.ex
+++ b/lib/machine_gun.ex
@@ -3,6 +3,8 @@ defmodule MachineGun do
 
   alias MachineGun.{Supervisor, Worker}
 
+  require Logger
+
   @default_request_timeout 5000
   @default_pool_timeout 1000
   @default_pool_size 4
@@ -167,6 +169,8 @@ defmodule MachineGun do
                 |> Map.get(:conn_opts, %{})
               )
 
+            Logger.info "Conn_ops before merge: #{inspect conn_opts}"
+
             conn_opts =
               %{
                 retry: 0,
@@ -175,6 +179,8 @@ defmodule MachineGun do
                 transport: transport
               }
               |> Map.merge(conn_opts)
+
+            Logger.info "Conn_ops after merge: #{inspect conn_opts}"
 
             case ensure_pool(pool, host, port, size, max_overflow, conn_opts) do
               :ok ->

--- a/lib/machine_gun.ex
+++ b/lib/machine_gun.ex
@@ -90,7 +90,7 @@ defmodule MachineGun do
 
         {transport, protocols} =
           case scheme do
-            "http" -> {:tcp, [:http2]}
+            "http" -> {:tcp, [:http]}
             "https" -> {:ssl, [:http2, :http]}
           end
 

--- a/lib/machine_gun.ex
+++ b/lib/machine_gun.ex
@@ -88,7 +88,7 @@ defmodule MachineGun do
 
         {transport, protocols} =
           case scheme do
-            "http" -> {:tcp, [:http]}
+            "http" -> {:tcp, [:http2]}
             "https" -> {:ssl, [:http2, :http]}
           end
 

--- a/lib/machine_gun.ex
+++ b/lib/machine_gun.ex
@@ -13,7 +13,8 @@ defmodule MachineGun do
       :request_url,
       :status_code,
       :headers,
-      :body
+      :body,
+      :trailers
     ]
   end
 
@@ -87,7 +88,7 @@ defmodule MachineGun do
 
         {transport, protocols} =
           case scheme do
-            "http" -> {:tcp, [:http]}
+            "http" -> {:tcp, [:http2, :http]}
             "https" -> {:ssl, [:http2, :http]}
           end
 

--- a/lib/machine_gun.ex
+++ b/lib/machine_gun.ex
@@ -88,7 +88,7 @@ defmodule MachineGun do
 
         {transport, protocols} =
           case scheme do
-            "http" -> {:tcp, [:http2, :http]}
+            "http" -> {:tcp, [:http2]}
             "https" -> {:ssl, [:http2, :http]}
           end
 

--- a/lib/machine_gun.ex
+++ b/lib/machine_gun.ex
@@ -88,7 +88,7 @@ defmodule MachineGun do
 
         {transport, protocols} =
           case scheme do
-            "http" -> {:tcp, [:http2]}
+            "http" -> {:tcp, [:http]}
             "https" -> {:ssl, [:http2, :http]}
           end
 

--- a/lib/machine_gun.ex
+++ b/lib/machine_gun.ex
@@ -3,8 +3,6 @@ defmodule MachineGun do
 
   alias MachineGun.{Supervisor, Worker}
 
-  require Logger
-
   @default_request_timeout 5000
   @default_pool_timeout 1000
   @default_pool_size 4
@@ -169,8 +167,6 @@ defmodule MachineGun do
                 |> Map.get(:conn_opts, %{})
               )
 
-            Logger.info "Conn_ops before merge: #{inspect conn_opts}"
-
             conn_opts =
               %{
                 retry: 0,
@@ -179,8 +175,6 @@ defmodule MachineGun do
                 transport: transport
               }
               |> Map.merge(conn_opts)
-
-            Logger.info "Conn_ops after merge: #{inspect conn_opts}"
 
             case ensure_pool(pool, host, port, size, max_overflow, conn_opts) do
               :ok ->


### PR DESCRIPTION
Add trailers support for HTTP/2 response. 
Reason: need it for GRPC calls.