### PR TITLE
Make it possible to not add requests to 'waiting' queue in poolboy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ HTTP client for Elixir. Based on [Gun](https://github.com/ninenines/gun) and [Po
     "https://httpbin.org/anything",
     "{\"hello\":\"world!\"}",
     [{"content-type", "application/json"}, {"accept", "application/json"}],
-    %{pool_timeout: 1000, request_timeout: 5000, pool_group: :default})
+    %{pool_queue: true, pool_timeout: 1000, request_timeout: 5000, pool_group: :default})
 ```
 
-Options are included to show defaults and can be omitted. `pool_timeout` and `request_timeout` default to values specified in pool group configuration. If not specified in pool group configuration they default to the values in the example.
+Options are included to show defaults and can be omitted. `pool_queue`, `pool_timeout` and `request_timeout` default to values specified in pool group configuration. If not specified in pool group configuration they default to the values in the example.
 
 ## Configuration
 
@@ -32,6 +32,7 @@ config :machine_gun,
   default: %{
     pool_size: 4,         # Poolboy size
     pool_max_overflow: 4, # Poolboy max_overflow
+    pool_queue: true,     # Queue requests if no workers are available in the pool. If `false` request will fail immediately if all workers are busy
     pool_timeout: 1000,
     request_timeout: 5000,
     conn_opts: %{}        # Gun connection options


### PR DESCRIPTION
When `:poolboy.transaction/3` is used, poolboy puts the request into a
'waiting' queue if all workers are busy. The caller is then blocked until a
worker becomes available and the request is processed (or passed timeout value
is reached). This is helpful during short load spikes, however if the overload
is sustained, the queue can become too expensive to manage: poolboy uses
`:queue.filter/2` to remove items from the queue, which is an O(n) operation.

It may be preferable to not add a request to the queue and abandon it
immediately if all workers are busy to avoid overloading the pool and ensuring
that new requests that come in don't have to wait for the ever-growing queue of
previous requests is processed.

This commit adds a configuration option for disabling adding a request to the
'waiting' queue: poolboy allows to do that when `:poolboy.checkout/3` is used
instead of `:poolboy.transaction/3`. The default value for the option is
`true`, which is the current behaviour.