### PR TITLE
upgrade elixir / add typespecs / fix dyalizer complaints

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.0.3
-elixir 1.10.4-otp-23
+erlang 24.1.7
+elixir 1.13.4

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/lib/machine_gun.ex
+++ b/lib/machine_gun.ex
@@ -1,10 +1,10 @@
 defmodule MachineGun do
   @moduledoc ""
 
-  alias MachineGun.{Supervisor, Worker}
+  alias MachineGun.{Supervisor, Worker, Response, Request}
 
-  @type request_headers() :: [Tuple.t(), ...] | []
-  @type request_opts() :: [Tuple.t(), ...] | [] | map
+  @type request_headers() :: [tuple(), ...] | []
+  @type request_opts() :: [tuple(), ...] | [] | map
   @type response_or_error :: {:ok, Response.t()} | {:error, any}
 
   @callback head(String.t(), request_headers(), request_opts()) :: response_or_error()
@@ -36,6 +36,14 @@ defmodule MachineGun do
       :body,
       :trailers
     ]
+
+    @type t :: %__MODULE__{
+            request_url: String.t(),
+            status_code: pos_integer(),
+            headers: map(),
+            body: String.t(),
+            trailers: any()
+          }
   end
 
   defmodule Request do
@@ -45,6 +53,13 @@ defmodule MachineGun do
       :headers,
       :body
     ]
+
+    @type t :: %__MODULE__{
+            method: String.t(),
+            path: String.t(),
+            headers: map(),
+            body: String.t()
+          }
   end
 
   defmodule Error do
@@ -221,7 +236,7 @@ defmodule MachineGun do
             end
         end
 
-      %URI{} ->
+      %URI{scheme: scheme} when is_nil(scheme) or is_binary(scheme) ->
         {:error, %Error{reason: :bad_url_scheme}}
 
       _ ->

--- a/lib/machine_gun/sup.ex
+++ b/lib/machine_gun/sup.ex
@@ -19,6 +19,8 @@ defmodule MachineGun.Supervisor do
       MachineGun.Supervisor,
       Supervisor.child_spec(
         %{
+          id: name,
+          restart: :permanent,
           start:
             {:poolboy, :start_link,
              [
@@ -30,14 +32,13 @@ defmodule MachineGun.Supervisor do
                  strategy: strategy
                ],
                [
-                 host |> String.to_charlist(),
+                 String.to_charlist(host),
                  port,
                  conn_opts
                ]
              ]}
         },
-        restart: :permanent,
-        id: nil
+        []
       )
     )
   end

--- a/lib/machine_gun/sup.ex
+++ b/lib/machine_gun/sup.ex
@@ -19,7 +19,7 @@ defmodule MachineGun.Supervisor do
       MachineGun.Supervisor,
       Supervisor.child_spec(
         %{
-          id: name,
+          id: nil,
           restart: :permanent,
           start:
             {:poolboy, :start_link,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule MachineGun.Mixfile do
     [
       app: :machine_gun,
       version: "0.1.8",
-      elixir: "~> 1.5",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
@@ -32,6 +32,7 @@ defmodule MachineGun.Mixfile do
 
   defp deps do
     [
+      {:dialyxir, "~> 1.1", only: [:dev], runtime: false},
       {:gun, "~> 1.3"},
       {:poolboy, "~> 1.5"},
       {:ex_doc, ">= 0.0.0", only: :dev}


### PR DESCRIPTION
Hey @petrohi 

We've at 8x8 decided to upgrade elixir and add typespecs to machine gun since we depend on it. Dialyzer complains that it's not a good practice to add structs within typespecs (eg. `@spec do_something() :: {:ok, %MachineGun.Response{}} | {:error, any()}`. Hence we're fixing the root cause, namely adding typespecs to MachineGun. 

Besides this I took the liberty to bump the elixir version to latest and also fix dialyzer complaints.

Note: Within the MachineGun.Supervisor, I've moved the `id` and `restart` properties upwards instead of having them as overrides. According to the docs `id` is required.